### PR TITLE
친구 초대하기 버튼 클릭 시 토스트 메시지 수정

### DIFF
--- a/src/screens/friend-main/invite-friend.tsx
+++ b/src/screens/friend-main/invite-friend.tsx
@@ -157,7 +157,7 @@ export default function InviteFriend({ diary }: InviteFriendProps) {
                 // setAlertMessage(`${nickname} 님을 초대헀어요.`);
                 // setAlertOpen(true)
 
-                setMessage(`${nickname} 님을 초대헀어요.`);
+                setMessage(`${nickname} 님을 초대했어요.`);
                 setSnackVisible(true);
 
                 await findNickname();


### PR DESCRIPTION
친구 검색해서 [초대]버튼 누를 시

토스트 메시지에

“초대헀어요” 라고 나오는거 “초대했어요”로 오타 수정